### PR TITLE
OpenLineage extractor

### DIFF
--- a/.idea/bacalhau-airflow-provider.iml
+++ b/.idea/bacalhau-airflow-provider.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/bacalhau-airflow-provider.iml" filepath="$PROJECT_DIR$/.idea/bacalhau-airflow-provider.iml" />
+    </modules>
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -50,6 +50,50 @@ airflow dags test bacalhau-integer-sum
 
 Head over to http://0.0.0.0:8080 to inspect the running dags.
 
+## OpenLineage integration
+
+For data lineage, the Bacalhau operator integrates the methods `get_openlineage_facets_on_start` and
+`get_openlineage_facets_on_complete`. It allows it to be compliant with `openlineage-airflow` standards to collect metadata
+
+### Configuration
+
+Along an Airflow instance, a client needs an OpenLineage compatible backend. In our case we will be focusing on [Marquez](https://github.com/MarquezProject/marquez),
+an open source solution for he collection, aggregation, and visualization of a data ecosystem's metadata.
+
+To setup a Marquez backend, it is advised to follow the [Quickstart](https://github.com/MarquezProject/marquez#quickstart) 
+from their README.
+
+Once the backend runs, an environment variable needs to be set to our Airflow components, `OPENLINEAGE_URL`. This variable
+will tell the `openlineage-airflow` library where to write our executions metadata. For a complete list of the available 
+variables, see [OpenLineage doc](https://openlineage.io/docs/integrations/airflow/usage#environment-variables).
+
+
+### How it works
+
+The `openlineage-airflow` library integrated in will run the methods as so:
+1. On TaskInstance start, collect metadata for each task
+2. Collect task input / output metadata (source, schema, etc) with the `get_openlineage_facets_on_start` method
+3. Collect task run-level metadata (execution time, state, parameters, etc) with `get_openlineage_facets_on_complete` method
+4. On TaskInstance complete, also mark the task as complete in Marquez
+
+### Extracted metadata
+
+The information that we are extracted through this Operator are:
+- ID: Unique global ID of this job in the bacalhau network.
+- ClientID: ID of the client that created this job.
+- Inputs: Data volumes read in the job
+- Outputs: Data volumes we will write in the job
+
+In the future it would be nice to also support:
+- APIVersion: APIVersion of the Job
+- CreatedAt: Time the job was submitted to the bacalhau network
+- [Spec fields in the Job model](https://github.com/filecoin-project/bacalhau/blob/main/pkg/model/job.go#L211)
+
+### Contributing
+
+Before contributing, refer to [OpenLineage doc](https://openlineage.io/docs/integrations/airflow/operator) to understand
+the data schemas that can be used in OpenLineage.
+
 ### Questions?
 
 If you have any questions or feedback, please reach out to `enricorotundo` on the `#bacalhau` channel in [Filecoin Slack](https://filecoin.io/slack).


### PR DESCRIPTION
The goal of this PR is to iterate over a potential implementation of an OpenLineage Airflow extractor as per [OpenLineage standards](https://openlineage.io/docs/integrations/airflow/usage)

In that regard, I have started to write some documentation in the README about how the whole thing works and what are the metadata to be extracted. I also specified the configuration that should be done on a client side that wishes to use the OpenLineage/Marquez integration.

Currently facing some trouble to exactly get the data that we want to extract. The data is passed to OpenLineage/Marquez through 2 methods: `get_openlineage_facets_on_start` & `get_openlineage_facets_on_complete`.

For `get_openlineage_facets_on_start`, we get our metadata from the instantiated operator (`self`) so we should ensure that all metadata that we want to extract before the execution of the task can be properly accessed as properties.

For `get_openlineage_facets_on_complete` we got access to the object but also to the [`task_instance`](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/taskinstance/index.html) created by airflow.

To progress further, we need to ensure that for each Operator that are implemented in this repository we properly get accessed to our desired metadata through what I described above.
